### PR TITLE
Readme about CORS headers and label change

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,19 @@ or
 ```
 {{ page.media['myimage.jpg'].nocdn.cropResize(500,200).grayscale }}
 ```
+
+### Important note about font files
+
+If you are hosting custom font files (eot, ttf, otf, or woff) you need to be aware that it requires setting the Access-Control-Allow-Origin header to the domain serving your Grav site or use wildcard-origin (*).
+
+```
+# Apache config
+<FilesMatch ".(eot|ttf|otf|woff)">
+	Header set Access-Control-Allow-Origin "*"
+</FilesMatch>
+
+# nginx config
+if ($filename ~* ^.*?\.(eot)|(ttf)|(woff)$){
+	add_header Access-Control-Allow-Origin *;
+}
+```

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -29,17 +29,17 @@ form:
 
     pullzone:
       type: text
-      label: Login path
+      label: CDN Domain
       default: "yourdomain.cdn.com"
       placeholder: "yourdomain.cdn.com"
-      help: Pullzone domain
+      help: The domain hosting your CDN distribution eg. cdn.getgrav.org
 
     tags:
       type: text
       label: Tags
       default: a|link|img|script
       placeholder: "a|link|img|script"
-      help: HTML tags to search
+      help: HTML tags to search and replace with CDN url
 
     tag_attributes:
       type: text


### PR DESCRIPTION
Adding info seciton to README.md about the need of CORS headers when loading font files cross origin which is often the case with a CDN.

Also adjusted the field label of pullzone domain as it said 'Login path'