### PR TITLE
fix: regex correctly matches url() referenced assets

### DIFF
--- a/cdn.php
+++ b/cdn.php
@@ -76,7 +76,11 @@ class CdnPlugin extends Plugin
 
         // replacements for inline CSS url() style references
         if ($config['inline_css_replace']) {
-            $regex = "/(url\()(?:" . $base . ")(.*?\.(?:" . $extensions . "))(.*;)/i";
+
+            // https://regex101.com/r/8zAnec/2 -> (url\([\'\"])(?:)(.*?\.(?:jpe?g|png|gif|ttf|otf|svg|woff|xml|js|css))(.*?\);)/i
+            // or with $base
+            // https://regex101.com/r/g0R6sj/2 -> (url\([\'\"])(?:http:\/\/github\.com)(.*?\.(?:jpe?g|png|gif|ttf|otf|svg|woff|xml|js|css))(.*?\);)/i
+            $regex = "/(url\([\'])(?:" . $base . ")(.*?\.(?:" . $extensions . "))(.*?\);)/i";
 
             $this->grav->output = preg_replace_callback(
                 $regex,

--- a/cdn.php
+++ b/cdn.php
@@ -80,7 +80,7 @@ class CdnPlugin extends Plugin
             // https://regex101.com/r/8zAnec/2 -> (url\([\'\"])(?:)(.*?\.(?:jpe?g|png|gif|ttf|otf|svg|woff|xml|js|css))(.*?\);)/i
             // or with $base
             // https://regex101.com/r/g0R6sj/2 -> (url\([\'\"])(?:http:\/\/github\.com)(.*?\.(?:jpe?g|png|gif|ttf|otf|svg|woff|xml|js|css))(.*?\);)/i
-            $regex = "/(url\([\'])(?:" . $base . ")(.*?\.(?:" . $extensions . "))(.*?\);)/i";
+            $regex = "/(url\([\'\"])(?:" . $base . ")(.*?\.(?:" . $extensions . "))(.*?\);)/i";
 
             $this->grav->output = preg_replace_callback(
                 $regex,


### PR DESCRIPTION
Additionally, adjusted how greedy the regex is and added
links out to Regex101.com for easy future reference

This fix addresses the issue reported here:
https://github.com/getgrav/grav-plugin-cdn/issues/7