### PR TITLE
Add .ico to the list of default extensions.

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -74,8 +74,8 @@ form:
     extensions:
       type: text
       label: Extensions
-      default: jpe?g|png|gif|ttf|otf|svg|woff|xml|js|css
-      placeholder: "jpe?g|png|gif|ttf|otf|svg|woff|xml|js|css"
+      default: jpe?g|png|gif|ico|ttf|otf|svg|woff|xml|js|css
+      placeholder: "jpe?g|png|gif|ico|ttf|otf|svg|woff|xml|js|css"
       help: File extensions to replace on
 
     valid_formats:

--- a/cdn.yaml
+++ b/cdn.yaml
@@ -1,9 +1,9 @@
-enabled: true                                           # set to false to disable this plugin completely
-forcehttps: false                                       # Force HTTPS regardless of SERVER_HTTPS
-inline_css_replace: true                                # Replace inline css url() references
-pullzone: yourdomain.cdn.com                            # pullzone domain
-tags: 'a|link|img|script'                               # HTML tags to search
-tag_attributes: 'href|src'                              # HTML tag attributes to search
-extensions: 'jpe?g|png|gif|ttf|otf|svg|woff|xml|js|css' # File extensions to replace on
-valid_formats:                                          # Valid formats
+enabled: true                                               # set to false to disable this plugin completely
+forcehttps: false                                           # Force HTTPS regardless of SERVER_HTTPS
+inline_css_replace: true                                    # Replace inline css url() references
+pullzone: yourdomain.cdn.com                                # pullzone domain
+tags: 'a|link|img|script'                                   # HTML tags to search
+tag_attributes: 'href|src'                                  # HTML tag attributes to search
+extensions: 'jpe?g|png|gif|ico|ttf|otf|svg|woff|xml|js|css' # File extensions to replace on
+valid_formats:                                              # Valid formats
   - html


### PR DESCRIPTION
Though mostly obsolete, a lot of the kitchen-sink favicon generators will still include a .ico along with the PNG versions.  This adds it to the list of default extensions.
